### PR TITLE
Cast AccountNumber string to integer

### DIFF
--- a/lib/fortnox/api/types.rb
+++ b/lib/fortnox/api/types.rb
@@ -38,6 +38,7 @@ module Fortnox
       AccountNumber = Strict::Int
                       .constrained(gteq: 0, lteq: 9999)
                       .optional
+                      .constructor(Dry::Types::Coercions::Form.method(:to_int))
 
       ArticleType = Strict::String
                     .constrained(included_in: ArticleTypes.values)

--- a/lib/fortnox/api/types.rb
+++ b/lib/fortnox/api/types.rb
@@ -38,7 +38,15 @@ module Fortnox
       AccountNumber = Strict::Int
                       .constrained(gteq: 0, lteq: 9999)
                       .optional
-                      .constructor(Dry::Types::Coercions::Form.method(:to_int))
+                      .constructor do |input|
+                        unless input.nil? || input.to_s.empty?
+                          Integer(input)
+                        else
+                          input
+                        end
+                      rescue ArgumentError
+                        input
+                      end
 
       ArticleType = Strict::String
                     .constrained(included_in: ArticleTypes.values)

--- a/spec/fortnox/api/types/account_number_spec.rb
+++ b/spec/fortnox/api/types/account_number_spec.rb
@@ -14,16 +14,26 @@ describe Fortnox::API::Types do
   end
 
   context 'when AccountNumber created with valid number' do
-    subject { klass['1234'] }
-
-    it { is_expected.to eq 1234 }
+    include_examples 'equals input', 1234
   end
 
   context 'when AccountNumber created with a too large number' do
-    include_examples 'raises ConstraintError', '10000'
+    include_examples 'raises ConstraintError', 10_000
   end
 
   context 'when AccountNumber created with a negative number' do
-    include_examples 'raises ConstraintError', '-1'
+    include_examples 'raises ConstraintError', -1
+  end
+
+  context 'when AccountNumber created with an invalid string' do
+    include_examples 'raises ConstraintError', 'foo'
+  end
+
+  context 'when AccountNumber created with valid string' do
+    subject { klass['1234'] }
+
+    it 'casts it to a number' do
+      is_expected.to eq 1234
+    end
   end
 end

--- a/spec/fortnox/api/types/account_number_spec.rb
+++ b/spec/fortnox/api/types/account_number_spec.rb
@@ -13,19 +13,17 @@ describe Fortnox::API::Types do
     it { is_expected.to be_nil }
   end
 
-  context 'when AccountNumber created with empty string' do
-    include_examples 'raises ConstraintError', ''
-  end
-
   context 'when AccountNumber created with valid number' do
-    include_examples 'equals input', 1234
+    subject { klass['1234'] }
+
+    it { is_expected.to eq 1234 }
   end
 
   context 'when AccountNumber created with a too large number' do
-    include_examples 'raises ConstraintError', 10_000
+    include_examples 'raises ConstraintError', '10000'
   end
 
   context 'when AccountNumber created with a negative number' do
-    include_examples 'raises ConstraintError', -1
+    include_examples 'raises ConstraintError', '-1'
   end
 end

--- a/spec/fortnox/api/types/account_number_spec.rb
+++ b/spec/fortnox/api/types/account_number_spec.rb
@@ -13,6 +13,10 @@ describe Fortnox::API::Types do
     it { is_expected.to be_nil }
   end
 
+  context 'when AccountNumber created with empty string' do
+    include_examples 'raises ConstraintError', ''
+  end
+
   context 'when AccountNumber created with valid number' do
     include_examples 'equals input', 1234
   end


### PR DESCRIPTION
According to the documentation at https://developer.fortnox.se/documentation/resources/customers/
the field `SalesAccount` on the `Customer` is a 4 digit string.