### PR TITLE
Fixes deprecation warning

### DIFF
--- a/lib/fortnox/api/models/document.rb
+++ b/lib/fortnox/api/models/document.rb
@@ -109,7 +109,7 @@ module Fortnox
         # HouseWork If there is any row of the document marked "housework".
         attribute :housework, Types::Nullable::Boolean.is(:read_only)
 
-        attribute :labels, Types::Strict::Array.member(Label)
+        attribute :labels, Types::Strict::Array.of(Label)
 
         # Net Net amount
         attribute :net, Types::Nullable::Float.is(:read_only)

--- a/lib/fortnox/api/models/invoice.rb
+++ b/lib/fortnox/api/models/invoice.rb
@@ -50,7 +50,7 @@ module Fortnox
         attribute :invoice_period_end, Types::Nullable::Date.is(:read_only)
 
         # InvoiceRows Separate object
-        attribute :invoice_rows, Types::Strict::Array.member(Types::InvoiceRow)
+        attribute :invoice_rows, Types::Strict::Array.of(Types::InvoiceRow)
 
         # InvoiceType The type of invoice.
         attribute :invoice_type, Types::Nullable::String

--- a/lib/fortnox/api/models/order.rb
+++ b/lib/fortnox/api/models/order.rb
@@ -20,7 +20,7 @@ module Fortnox
         attribute :order_date, Types::Nullable::Date
 
         # OrderRows Separate object
-        attribute :order_rows, Types::Strict::Array.member(Types::OrderRow)
+        attribute :order_rows, Types::Strict::Array.of(Types::OrderRow)
       end
     end
   end

--- a/spec/fortnox/api/mappers/contexts/json_conversion.rb
+++ b/spec/fortnox/api/mappers/contexts/json_conversion.rb
@@ -40,7 +40,7 @@ shared_context 'with JSON conversion' do
         attribute :url, 'strict.string'
         attribute :name, 'strict.string'
         attribute :vat, 'strict.float'
-        attribute :categories, Dry::Types['coercible.array'].member(Test::Category)
+        attribute :categories, Dry::Types['coercible.array'].of(Test::Category)
         attribute :designer, Test::ProductDesigner
       end
     end


### PR DESCRIPTION
Fixes #161 

```
[dry-types] Dry::Types::Array#member is deprecated and will be removed
in the next major version. Please use Dry::Types::Array#of instead.
```