### PR TITLE
Fix 168 email regexp

### DIFF
--- a/lib/fortnox/api/types.rb
+++ b/lib/fortnox/api/types.rb
@@ -63,7 +63,7 @@ module Fortnox
                      .constructor(EnumConstructors.default)
 
       Email = Strict::String
-              .constrained(max_size: 1024, format: /^$|\A[\w+-_.]+@[\w+-_.]+\.[a-z]+\z/i)
+              .constrained(max_size: 1024, format: /^$|\A[[[:alnum:]]+-_.]+@[\w+-_.]+\.[a-z]+\z/i)
               .optional
               .constructor { |v| v.to_s.downcase unless v.nil? }
 

--- a/spec/fortnox/api/types/email_spec.rb
+++ b/spec/fortnox/api/types/email_spec.rb
@@ -20,13 +20,10 @@ describe Fortnox::API::Types::Email do
   end
 
   context 'when created with valid email' do
-    emails = ['valid@example.com', 'kanal_75_ab-faktura@mail.unit4agresso.readsoftonline.com']
+    valid_emails = ['valid@example.com', 'kanal_75_ab-faktura@mail.unit4agresso.readsoftonline.com']
 
-    emails.each do |email|
-      subject { described_class[input] }
-
-      let(:input) { email }
-      it { is_expected.to eq input }
+    valid_emails.each do |email|
+      it { expect(described_class[email]).to eq email }
     end
   end
 

--- a/spec/fortnox/api/types/email_spec.rb
+++ b/spec/fortnox/api/types/email_spec.rb
@@ -20,7 +20,11 @@ describe Fortnox::API::Types::Email do
   end
 
   context 'when created with valid email' do
-    valid_emails = ['valid@example.com', 'kanal_75_ab-faktura@mail.unit4agresso.readsoftonline.com']
+    valid_emails = [
+      'valid@example.com',
+      'kanal_75_ab-faktura@mail.unit4agresso.readsoftonline.com',
+      'sköldpadda@example.com'
+    ]
 
     valid_emails.each do |email|
       it { expect(described_class[email]).to eq email }


### PR DESCRIPTION
Improves Email regexp

Also fixes a bug in the Email spec. Se below example:
```
describe 'Test' do
  describe 'bad use of subject' do
    def double(number)
      number * 2
    end

    test_cases = [1, 2, 3]

    test_cases.each do |test_case|
      subject { double(test_case) }

      it { is_expected.to eq 1 }
    end
  end
end
```
This code runs 3 times, but the `subject` will always be `3`!