### PR TITLE
Rubocop update

### DIFF
--- a/fortnox-api.gemspec
+++ b/fortnox-api.gemspec
@@ -1,7 +1,6 @@
-
 # frozen_string_literal: true
 
-lib = File.expand_path('../lib', __FILE__)
+lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'fortnox/api/version'
 
@@ -36,7 +35,7 @@ Gem::Specification.new do |spec| # rubocop:disable Metrics/BlockLength
   spec.add_development_dependency 'rake', '>= 12.3.3'
   spec.add_development_dependency 'rspec', '~> 3.2'
   spec.add_development_dependency 'rspec-collection_matchers', '~> 0'
-  spec.add_development_dependency 'rubocop', '~> 0.52.0'
+  spec.add_development_dependency 'rubocop', '~> 0.62.0'
   spec.add_development_dependency 'rubocop-rspec', '~> 1.22.2'
   spec.add_development_dependency 'simplecov', '~> 0.15'
   spec.add_development_dependency 'vcr', '~> 4.0'

--- a/lib/fortnox/api.rb
+++ b/lib/fortnox/api.rb
@@ -29,12 +29,14 @@ module Fortnox
     setting :token_store, DEFAULT_CONFIGURATION[:token_store]
     setting :access_token, DEFAULT_CONFIGURATION[:access_token] do |value|
       next if value.nil? # nil is a valid unassigned value
+
       invalid_access_token_format!(value) unless value.is_a?(String)
       config.token_store = { default: value }
       value
     end
     setting :access_tokens, DEFAULT_CONFIGURATION[:access_tokens] do |value|
       next if value.nil? # nil is a valid unassigned value
+
       invalid_access_tokens_format!(value) unless value.is_a?(Hash) || value.is_a?(Array)
       config.token_store = value.is_a?(Hash) ? value : { default: value }
       value

--- a/lib/fortnox/api/mappers/base/from_json.rb
+++ b/lib/fortnox/api/mappers/base/from_json.rb
@@ -49,6 +49,7 @@ module Fortnox
                       " #{collection}"
 
             raise MissingModelOrMapperException, message if ENV['RUBY_ENV']
+
             Fortnox::API.logger.warn("Missing Model or Mapper implementation for #{key} with attributes: #{collection}")
             return convert_hash_keys_from_json_format(collection, {})
           end

--- a/lib/fortnox/api/mappers/base/to_json.rb
+++ b/lib/fortnox/api/mappers/base/to_json.rb
@@ -41,6 +41,7 @@ module Fortnox
           def sanitise(hash, keys_to_filter)
             hash.reject do |key, value|
               next false if keys_to_filter.include?(key)
+
               value.nil?
             end
           end

--- a/lib/fortnox/api/models/base.rb
+++ b/lib/fortnox/api/models/base.rb
@@ -66,6 +66,7 @@ module Fortnox
         # Generic comparison, by value, use .eql? or .equal? for object identity.
         def ==(other)
           return false unless other.is_a? self.class
+
           to_hash == other.to_hash
         end
 

--- a/lib/fortnox/api/models/base.rb
+++ b/lib/fortnox/api/models/base.rb
@@ -94,8 +94,6 @@ module Fortnox
           end
         end
 
-        private_class_method
-
         # dry-types filter anything that isn't specified as an attribute on the
         # class that is being instantiated. This wrapper preserves the meta
         # properties we need to track object state during that initilisation and
@@ -115,6 +113,8 @@ module Fortnox
 
           obj
         end
+
+        private_class_method :preserve_meta_properties
 
         private
 

--- a/lib/fortnox/api/models/customer.rb
+++ b/lib/fortnox/api/models/customer.rb
@@ -30,31 +30,31 @@ module Fortnox
         # Url Direct URL to the record
         attribute :url, Types::Nullable::String.is(:read_only)
 
-        # Address1	First address of the customer. 1024 characters
+        # Address1  First address of the customer. 1024 characters
         attribute :address1, Types::Sized::String[1024]
 
-        # Address2	Second address of the customer. 1024 characters
+        # Address2  Second address of the customer. 1024 characters
         attribute :address2, Types::Sized::String[1024]
 
-        # City	City of the customer. 1024 characters
+        # City  City of the customer. 1024 characters
         attribute :city, Types::Sized::String[1024]
 
-        # Country	Country of the customer. Read-only.
+        # Country  Country of the customer. Read-only.
         attribute :country, Types::Nullable::String.is(:read_only)
 
-        # Comments	Comments. 1024 characters.
+        # Comments  Comments. 1024 characters.
         attribute :comments, Types::Sized::String[1024]
 
-        # Currency	Currency of the customer, 3 letters
+        # Currency  Currency of the customer, 3 letters
         attribute :currency, Types::Currency
 
-        # CostCenter	Cost center of the customer, Cost center in Fortnox
+        # CostCenter  Cost center of the customer, Cost center in Fortnox
         attribute :cost_center, Types::Nullable::String
 
-        # CountryCode	Country code of the customer, 2 letters
+        # CountryCode  Country code of the customer, 2 letters
         attribute :country_code, Types::CountryCode
 
-        # CustomerNumber	Customer number. 1024 characters
+        # CustomerNumber  Customer number. 1024 characters
         attribute :customer_number, Types::Sized::String[1024]
 
         # DefaultDeliveryTypes The properties for this object is listed in the table for "Default Delivery Types".
@@ -63,146 +63,146 @@ module Fortnox
         # The properties for this object is listed in the table for "Default Templates".
         attribute :default_templates, Types::DefaultTemplates
 
-        # DeliveryAddress1	First delivery address of the customer. 1024 characters
+        # DeliveryAddress1  First delivery address of the customer. 1024 characters
         attribute :delivery_address1, Types::Sized::String[1024]
 
-        # DeliveryAddress2	Second delivery address of the customer. 1024 characters
+        # DeliveryAddress2  Second delivery address of the customer. 1024 characters
         attribute :delivery_address2, Types::Sized::String[1024]
 
-        # DeliveryCity	Delivery city of the customer. 1024 characters
+        # DeliveryCity  Delivery city of the customer. 1024 characters
         attribute :delivery_city, Types::Sized::String[1024]
 
-        # DeliveryCountry	Delivery country of the customer. Read-only.
+        # DeliveryCountry  Delivery country of the customer. Read-only.
         attribute :delivery_country, Types::Nullable::String.is(:read_only)
 
-        # DeliveryCountryCode	Delivery country code of the customer, 2 letters
+        # DeliveryCountryCode  Delivery country code of the customer, 2 letters
         attribute :delivery_country_code, Types::CountryCode
 
-        # DeliveryFax	Delivery fax number of the customer. 1024 characters
+        # DeliveryFax  Delivery fax number of the customer. 1024 characters
         attribute :delivery_fax, Types::Sized::String[1024]
 
-        # DeliveryName	Delivery name of the customer. 1024 characters
+        # DeliveryName  Delivery name of the customer. 1024 characters
         attribute :delivery_name, Types::Sized::String[1024]
 
-        # DeliveryPhone1	First delivery phone number of the customer. 1024 characters
+        # DeliveryPhone1  First delivery phone number of the customer. 1024 characters
         attribute :delivery_phone1, Types::Sized::String[1024]
 
-        # DeliveryPhone2	Second delivery phone number of the customer. 1024 characters
+        # DeliveryPhone2  Second delivery phone number of the customer. 1024 characters
         attribute :delivery_phone2, Types::Sized::String[1024]
 
-        # DeliveryZipCode	Delivery zip code of the customer. 1024 characters.
+        # DeliveryZipCode  Delivery zip code of the customer. 1024 characters.
         attribute :delivery_zip_code, Types::Sized::String[1024]
 
-        # Email	Email address of the customer. 1024 characters
+        # Email  Email address of the customer. 1024 characters
         attribute :email, Types::Email
 
-        # EmailInvoice	Invoice email address of the customer. 1024 characters
+        # EmailInvoice  Invoice email address of the customer. 1024 characters
         attribute :email_invoice, Types::Email
 
-        # EmailInvoiceBCC	Invoice BCC email address of the customer. 1024 characters
+        # EmailInvoiceBCC  Invoice BCC email address of the customer. 1024 characters
         attribute :email_invoice_bcc, Types::Email
 
-        # EmailInvoiceCC	Invoice CC email address of the customer. 1024 characters
+        # EmailInvoiceCC  Invoice CC email address of the customer. 1024 characters
         attribute :email_invoice_cc, Types::Email
 
-        # EmailOffer	Offer email address of the customer. 1024 characters
+        # EmailOffer  Offer email address of the customer. 1024 characters
         attribute :email_offer, Types::Email
 
-        # EmailOfferBCC	Offer BCC email address of the customer. 1024 characters
+        # EmailOfferBCC  Offer BCC email address of the customer. 1024 characters
         attribute :email_offer_bcc, Types::Email
 
-        # EmailOfferCC	Offer CC email address of the customer. 1024 characters
+        # EmailOfferCC  Offer CC email address of the customer. 1024 characters
         attribute :email_offer_cc, Types::Email
 
-        # EmailOrder	Order email address of the customer. 1024 characters
+        # EmailOrder  Order email address of the customer. 1024 characters
         attribute :email_order, Types::Email
 
-        # EmailOrderBCC	Order BCC email address of the customer. 1024 characters
+        # EmailOrderBCC  Order BCC email address of the customer. 1024 characters
         attribute :email_order_bcc, Types::Email
 
-        # EmailOrderCC	Order CC email address of the customer. 1024 characters
+        # EmailOrderCC  Order CC email address of the customer. 1024 characters
         attribute :email_order_cc, Types::Email
 
-        # Fax	Fax number of the customer. 1024 characters
+        # Fax  Fax number of the customer. 1024 characters
         attribute :fax, Types::Sized::String[1024]
 
         # InvoiceAdministrationFee  Invoice administration fee of the customer, 12 digits (incl. decimals).
         attribute :invoice_administration_fee,
                   Types::Sized::Float[0.0, 99_999_999_999.9]
 
-        # InvoiceDiscount	Invoice discount of the customer, 12 digits (incl. decimals)
+        # InvoiceDiscount  Invoice discount of the customer, 12 digits (incl. decimals)
         attribute :invoice_discount, Types::Sized::Float[0.0, 99_999_999_999.9]
 
-        # InvoiceFreight	Invoice freight fee of the customer, 12 digits (incl. decimals)
+        # InvoiceFreight  Invoice freight fee of the customer, 12 digits (incl. decimals)
         attribute :invoice_freight, Types::Sized::Float[0.0, 99_999_999_999.9]
 
-        # InvoiceRemark	Invoice remark of the customer. 1024 characters
+        # InvoiceRemark  Invoice remark of the customer. 1024 characters
         attribute :invoice_remark, Types::Sized::String[1024]
 
-        # Name	Name of the customer, 1024 characters
+        # Name  Name of the customer, 1024 characters
         attribute :name, Types::Sized::String[1024].is(:required)
 
-        # OrganisationNumber	Organisation number of the customer. 30 characters
+        # OrganisationNumber  Organisation number of the customer. 30 characters
         attribute :organisation_number, Types::Sized::String[30]
 
-        # OurReference	Our reference of the customer. 50 characters
+        # OurReference  Our reference of the customer. 50 characters
         attribute :our_reference, Types::Sized::String[50]
 
-        # Phone1	First phone number of the customer. 1024 characters
+        # Phone1  First phone number of the customer. 1024 characters
         attribute :phone1, Types::Sized::String[1024]
 
-        # Phone2	Second phone number of the customer. 1024 characters
+        # Phone2  Second phone number of the customer. 1024 characters
         attribute :phone2, Types::Sized::String[1024]
 
-        # PriceList	Price list of the customer, Price list in Fortnox
+        # PriceList  Price list of the customer, Price list in Fortnox
         attribute :price_list, Types::Nullable::String
 
-        # Project	Project of the customer, Project in Fortnox
+        # Project  Project of the customer, Project in Fortnox
         attribute :project, Types::Nullable::String
 
-        # SalesAccount	Sales account of the customer, 4 digits
+        # SalesAccount  Sales account of the customer, 4 digits
         attribute :sales_account, Types::AccountNumber
 
-        # ShowPriceVATIncluded	Show prices with VAT included or not
+        # ShowPriceVATIncluded  Show prices with VAT included or not
         attribute :show_price_vat_included, Types::Nullable::Boolean
 
-        # TermsOfDeliveryCode	Terms of delivery code of the customer
+        # TermsOfDeliveryCode  Terms of delivery code of the customer
         attribute :terms_of_delivery, Types::Nullable::String
 
-        # TermsOfPaymentCode	Terms of payment code of the customer
+        # TermsOfPaymentCode  Terms of payment code of the customer
         attribute :terms_of_payment, Types::Nullable::String
 
-        # Type	Customer type, PRIVATE / COMPANY
+        # Type  Customer type, PRIVATE / COMPANY
         attribute :type, Types::CustomerType
 
-        # VATNumber	VAT number of the customer
+        # VATNumber  VAT number of the customer
         attribute :vat_number, Types::Nullable::String
 
-        # VATType	VAT type of the customer, SEVAT / SEREVERSEDVAT / EUREVERSEDVAT / EUVAT / EXPORT
+        # VATType  VAT type of the customer, SEVAT / SEREVERSEDVAT / EUREVERSEDVAT / EUVAT / EXPORT
         attribute :vat_type, Types::VATType
 
-        # VisitAddress	Visit address of the customer. 128 characters
+        # VisitAddress  Visit address of the customer. 128 characters
         attribute :visiting_address, Types::Sized::String[128]
 
-        # VisitCity	Visit city of the customer. 128 characters
+        # VisitCity  Visit city of the customer. 128 characters
         attribute :visiting_city, Types::Sized::String[128]
 
-        # VisitCountry	Visit country of the customer, read-only
+        # VisitCountry  Visit country of the customer, read-only
         attribute :visiting_country, Types::Nullable::String.is(:read_only)
 
         # VisitingCountryCode Code of the visiting country for the customer, 2 letters
         attribute :visiting_country_code, Types::CountryCode
 
-        # VisitZipCode	Visit zip code of the customer. 10 characters
+        # VisitZipCode  Visit zip code of the customer. 10 characters
         attribute :visiting_zip_code, Types::Sized::String[10]
 
-        # WayOfDeliveryCode	Way of delivery code of the customer
+        # WayOfDeliveryCode  Way of delivery code of the customer
         attribute :way_of_delivery, Types::Nullable::String
 
-        # YourReference	Your reference of the customer. 50 characters
+        # YourReference  Your reference of the customer. 50 characters
         attribute :your_reference, Types::Sized::String[50]
 
-        # ZipCode	Zip code of the customer. 10 characters
+        # ZipCode  Zip code of the customer. 10 characters
         attribute :zip_code, Types::Sized::String[10]
       end
     end

--- a/lib/fortnox/api/models/label.rb
+++ b/lib/fortnox/api/models/label.rb
@@ -8,10 +8,10 @@ module Fortnox
       class Label < Model::Base
         STUB = {}.freeze
 
-        # Id	integer, read-only. The ID of the label.
+        # Id  integer, read-only. The ID of the label.
         attribute :id, Types::Required::Integer.is(:read_only)
 
-        # Description	string, 25 characters, required. Description of the label
+        # Description  string, 25 characters, required. Description of the label
         attribute :description, Types::Sized::String[25].is(:read_only)
       end
     end

--- a/lib/fortnox/api/repositories/base.rb
+++ b/lib/fortnox/api/repositories/base.rb
@@ -57,6 +57,7 @@ module Fortnox
         def check_access_tokens!(tokens)
           tokens_present = !(tokens.nil? || tokens.empty?)
           return if tokens_present
+
           error_message = "You have not provided any access tokens in token store #{@token_store.inspect}."
           raise MissingConfiguration, error_message
         end
@@ -83,12 +84,14 @@ module Fortnox
         def base_url
           base_url = config.base_url
           raise MissingConfiguration, 'You have to provide a base url.' unless base_url
+
           base_url
         end
 
         def client_secret
           client_secret = config.client_secret
           raise MissingConfiguration, 'You have to provide your client secret.' unless client_secret
+
           client_secret
         end
 

--- a/lib/fortnox/api/repositories/base/savers.rb
+++ b/lib/fortnox/api/repositories/base/savers.rb
@@ -8,6 +8,7 @@ module Fortnox
           return true if entity.saved?
 
           return save_new(entity) if entity.new?
+
           update_existing(entity)
         end
 

--- a/lib/fortnox/api/request_handling.rb
+++ b/lib/fortnox/api/request_handling.rb
@@ -5,30 +5,30 @@ module Fortnox
     module RequestHandling
       private
 
-        def raise_api_error(error, response)
-          message = (error['message'] || error['Message'] || 'Okänt fel')
+      def raise_api_error(error, response)
+        message = (error['message'] || error['Message'] || 'Okänt fel')
 
-          message += "\n\n#{response.request.inspect}" if Fortnox::API.debugging
+        message += "\n\n#{response.request.inspect}" if Fortnox::API.debugging
 
-          raise Fortnox::API::RemoteServerError, message
-        end
+        raise Fortnox::API::RemoteServerError, message
+      end
 
-        def validate_response(response)
-          return if response.code == 200
+      def validate_response(response)
+        return if response.code == 200
 
-          api_error = response.parsed_response['ErrorInformation']
-          raise_api_error(api_error, response) if api_error
-        end
+        api_error = response.parsed_response['ErrorInformation']
+        raise_api_error(api_error, response) if api_error
+      end
 
-        def validate_and_parse(response)
-          validate_response(response)
-          response.parsed_response
-        end
+      def validate_and_parse(response)
+        validate_response(response)
+        response.parsed_response
+      end
 
-        def execute
-          response = yield(self.class)
-          validate_and_parse response
-        end
+      def execute
+        response = yield(self.class)
+        validate_and_parse response
+      end
     end
   end
 end

--- a/lib/fortnox/api/types.rb
+++ b/lib/fortnox/api/types.rb
@@ -43,6 +43,7 @@ module Fortnox
                       .optional
                       .constructor do |value|
                         next nil if value.nil? || value == ''
+
                         value
                       end
 
@@ -97,7 +98,7 @@ module Fortnox
       Email = Strict::String
               .constrained(max_size: 1024, format: /^$|\A[[[:alnum:]]+-_.]+@[\w+-_.]+\.[a-z]+\z/i)
               .optional
-              .constructor { |v| v.to_s.downcase unless v.nil? }
+              .constructor { |v| v&.to_s&.downcase }
 
       HouseworkType = Strict::String
                       .constrained(included_in: HouseworkTypes.values)

--- a/lib/fortnox/api/types/enums.rb
+++ b/lib/fortnox/api/types/enums.rb
@@ -7,6 +7,7 @@ module Fortnox
         def self.sized(size)
           lambda do |value|
             return nil if value == ''
+
             value.to_s.upcase[0...size] unless value.nil?
           end
         end
@@ -14,14 +15,16 @@ module Fortnox
         def self.default
           lambda do |value|
             return nil if value == ''
-            value.to_s.upcase unless value.nil?
+
+            value&.to_s&.upcase
           end
         end
 
         def self.lower_case
           lambda do |value|
             return nil if value == ''
-            value.to_s.downcase unless value.nil?
+
+            value&.to_s&.downcase
           end
         end
       end

--- a/lib/fortnox/api/types/nullable.rb
+++ b/lib/fortnox/api/types/nullable.rb
@@ -6,9 +6,9 @@ module Fortnox
   module API
     module Types
       module Nullable
-        String = Types::Strict::String.optional.constructor { |value| value.to_s unless value.nil? }
-        Float = Types::Strict::Float.optional.constructor { |value| value.to_f unless value.nil? }
-        Integer = Types::Strict::Int.optional.constructor { |value| value.to_i unless value.nil? }
+        String = Types::Strict::String.optional.constructor { |value| value&.to_s }
+        Float = Types::Strict::Float.optional.constructor { |value| value&.to_f }
+        Integer = Types::Strict::Int.optional.constructor { |value| value&.to_i }
         Boolean = Types::Bool.optional.constructor { |value| THE_TRUTH.fetch(value) { false } }
         # TODO: Improve parsing!
         # In case date parsing fails, ArgumentError is thrown. Currently, it is rescued in Repository::Loaders.find.

--- a/lib/fortnox/api/types/required.rb
+++ b/lib/fortnox/api/types/required.rb
@@ -4,9 +4,9 @@ module Fortnox
   module API
     module Types
       module Required
-        String = Types::Strict::String.constructor { |value| value.to_s unless value.nil? }.is(:required)
-        Integer = Types::Strict::Int.constructor { |value| value.to_i unless value.nil? }.is(:required)
-        Float = Types::Strict::Float.constructor { |value| value.to_f unless value.nil? }.is(:required)
+        String = Types::Strict::String.constructor { |value| value&.to_s }.is(:required)
+        Integer = Types::Strict::Int.constructor { |value| value&.to_i }.is(:required)
+        Float = Types::Strict::Float.constructor { |value| value&.to_f }.is(:required)
       end
     end
   end

--- a/lib/fortnox/api/types/sized.rb
+++ b/lib/fortnox/api/types/sized.rb
@@ -7,7 +7,7 @@ module Fortnox
         module String
           def self.[](size)
             Types::Strict::String.constrained(max_size: size).optional.constructor do |value|
-              value.to_s unless value.nil?
+              value&.to_s
             end
           end
         end
@@ -15,7 +15,7 @@ module Fortnox
         module Integer
           def self.[](low, high)
             Types::Strict::Int.constrained(gteq: low, lteq: high).optional.constructor do |value|
-              value.to_i unless value.nil?
+              value&.to_i
             end
           end
         end
@@ -23,7 +23,7 @@ module Fortnox
         module Float
           def self.[](low, high)
             Types::Strict::Float.constrained(gteq: low, lteq: high).optional.constructor do |value|
-              value.to_f unless value.nil?
+              value&.to_f
             end
           end
         end

--- a/spec/fortnox/api/mappers/contexts/json_conversion.rb
+++ b/spec/fortnox/api/mappers/contexts/json_conversion.rb
@@ -47,6 +47,7 @@ shared_context 'with JSON conversion' do
 
     def register_mapper(mapper_sym, mapper)
       return if Fortnox::API::Registry.key? mapper_sym
+
       Fortnox::API::Registry.register(mapper_sym, mapper)
     end
 

--- a/spec/fortnox/api/repositories/base_spec.rb
+++ b/spec/fortnox/api/repositories/base_spec.rb
@@ -339,8 +339,7 @@ describe Fortnox::API::Repository::Base do
   end
 
   context 'when raising error from remote server' do
-    error_message = 'Räkenskapsår finns inte upplagt. '\
-                    'För att kunna skapa en faktura krävs det att det finns ett räkenskapsår'
+    subject { -> { repository.post('/test', body: '') } }
 
     before do
       Fortnox::API.configure do |conf|
@@ -363,7 +362,10 @@ describe Fortnox::API::Repository::Base do
       )
     end
 
-    subject { -> { repository.post('/test', body: '') } }
+    let(:error_message) do
+      'Räkenskapsår finns inte upplagt. '\
+      'För att kunna skapa en faktura krävs det att det finns ett räkenskapsår'
+    end
 
     it { is_expected.to raise_error(Fortnox::API::RemoteServerError) }
     it { is_expected.to raise_error(error_message) }

--- a/spec/fortnox/api/repositories/examples/all.rb
+++ b/spec/fortnox/api/repositories/examples/all.rb
@@ -15,4 +15,3 @@ RSpec.shared_examples_for '.all' do |count|
     end
   end
 end
-# rubocop:enable RSpec/DescribeClass

--- a/spec/fortnox/api/repositories/examples/only.rb
+++ b/spec/fortnox/api/repositories/examples/only.rb
@@ -40,4 +40,3 @@ shared_examples_for '.only' do |matching_filter, expected_matches, missing_filte
     end
   end
 end
-# rubocop:enable RSpec/DescribeClass

--- a/spec/fortnox/api/repositories/examples/save.rb
+++ b/spec/fortnox/api/repositories/examples/save.rb
@@ -59,4 +59,3 @@ shared_examples_for '.save' do |attribute, additional_attrs: {}|
     end
   end
 end
-# rubocop:enable RSpec/DescribeClass

--- a/spec/fortnox/api/repositories/examples/save_with_nested_model.rb
+++ b/spec/fortnox/api/repositories/examples/save_with_nested_model.rb
@@ -30,4 +30,3 @@ shared_examples_for '.save with nested model' do |required_hash, nested_model_ke
     end
   end
 end
-# rubocop:enable RSpec/DescribeClass

--- a/spec/fortnox/api/repositories/examples/save_with_specially_named_attribute.rb
+++ b/spec/fortnox/api/repositories/examples/save_with_specially_named_attribute.rb
@@ -26,4 +26,3 @@ shared_examples_for '.save with specially named attribute' do |required_hash, at
     end
   end
 end
-# rubocop:enable RSpec/DescribeClass

--- a/spec/fortnox/api/repositories/examples/search.rb
+++ b/spec/fortnox/api/repositories/examples/search.rb
@@ -39,4 +39,3 @@ shared_examples_for '.search' do |attribute_hash_key_name, value, matches|
     end
   end
 end
-# rubocop:enable RSpec/DescribeClass

--- a/spec/fortnox/api/types/housework_types_spec.rb
+++ b/spec/fortnox/api/types/housework_types_spec.rb
@@ -72,6 +72,7 @@ describe 'HouseworkTypes', integration: true do
   it_behaves_like 'housework type', 'OTHERCARE', TYPE_RUT
   it_behaves_like 'housework type', 'OTHERCOSTS', TYPE_RUT, housework: false
 
+  # rubocop:disable RSpec/RepeatedExample
   # rubocop:disable RSpec/RepeatedDescription
   pending 'to be added' do
     raise Exception, 'Will be supported 2021-01-01'
@@ -88,6 +89,7 @@ describe 'HouseworkTypes', integration: true do
     # it_behaves_like 'housework type', 'CHARGINGSTATIONELECTRICVEHICLE', TYPE_GREEN
     # it_behaves_like 'housework type', 'OTHERCOSTS', TYPE_GREEN
   end
+  # rubocop:enable RSpec/RepeatedExample
   # rubocop:enable RSpec/RepeatedDescription
 
   it_behaves_like 'housework type', 'COOKING', TYPE_RUT, legacy: true

--- a/spec/fortnox/api/types/order_row_spec.rb
+++ b/spec/fortnox/api/types/order_row_spec.rb
@@ -5,9 +5,9 @@ require 'fortnox/api/types/order_row'
 require 'fortnox/api/types/examples/document_row'
 
 RSpec.describe Fortnox::API::Types::OrderRow, type: :type do
-  valid_hash = { ordered_quantity: 10.5 }
-
   subject { described_class }
+
+  valid_hash = { ordered_quantity: 10.5 }
 
   it { is_expected.to require_attribute(:ordered_quantity, valid_hash) }
 


### PR DESCRIPTION
Fixes #208 

Rubocop was too old to support Ruby 2.6 that we are now requiring. This lead to a crash in Codeclimate when it tried to run Rubocop.

This PR includes a lot of auto corrections from Rubocop. I made a few manual changes to fix some violations also. All testa are passing :smiley: 