### PR TITLE
Fixes crash in dry-types

### DIFF
--- a/lib/fortnox/api.rb
+++ b/lib/fortnox/api.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'set'
+require 'dry-configurable'
 require 'dry-struct'
 require 'logger'
 


### PR DESCRIPTION
Without this require, dry-types complains about
uninitialized constant Dry::Configurable (NameError)

```
from ~/.asdf/installs/ruby/2.7.6/lib/ruby/gems/2.7.0/bundler/gems/fortnox-api-4348fea55f3e/lib/fortnox/api.rb:4:in `<top (required)>'
from ~/.asdf/installs/ruby/2.7.6/lib/ruby/gems/2.7.0/bundler/gems/fortnox-api-4348fea55f3e/lib/fortnox/api.rb:4:in `require'
from ~/.asdf/installs/ruby/2.7.6/lib/ruby/gems/2.7.0/gems/dry-struct-0.4.0/lib/dry-struct.rb:1:in `<top (required)>'
from ~/.asdf/installs/ruby/2.7.6/lib/ruby/gems/2.7.0/gems/dry-struct-0.4.0/lib/dry-struct.rb:1:in `require'
from ~/.asdf/installs/ruby/2.7.6/lib/ruby/gems/2.7.0/gems/dry-struct-0.4.0/lib/dry/struct.rb:2:in `<top (required)>'
from ~/.asdf/installs/ruby/2.7.6/lib/ruby/gems/2.7.0/gems/dry-struct-0.4.0/lib/dry/struct.rb:2:in `require'
from ~/.asdf/installs/ruby/2.7.6/lib/ruby/gems/2.7.0/gems/dry-types-0.12.3/lib/dry-types.rb:1:in `<top (required)>'
from ~/.asdf/installs/ruby/2.7.6/lib/ruby/gems/2.7.0/gems/dry-types-0.12.3/lib/dry-types.rb:1:in `require'
from ~/.asdf/installs/ruby/2.7.6/lib/ruby/gems/2.7.0/gems/dry-types-0.12.3/lib/dry/types.rb:21:in `<top (required)>'
from ~/.asdf/installs/ruby/2.7.6/lib/ruby/gems/2.7.0/gems/dry-types-0.12.3/lib/dry/types.rb:21:in `require'
from ~/.asdf/installs/ruby/2.7.6/lib/ruby/gems/2.7.0/gems/dry-types-0.12.3/lib/dry/types/errors.rb:1:in `<top (required)>'
from ~/.asdf/installs/ruby/2.7.6/lib/ruby/gems/2.7.0/gems/dry-types-0.12.3/lib/dry/types/errors.rb:2:in `<module:Dry>'
~/.asdf/installs/ruby/2.7.6/lib/ruby/gems/2.7.0/gems/dry-types-0.12.3/lib/dry/types/errors.rb:3:in `<module:Types>': uninitialized constant Dry::Configurable (NameError)`
```