### PR TITLE
Fix dependencies

### DIFF
--- a/fortnox-api.gemspec
+++ b/fortnox-api.gemspec
@@ -23,13 +23,13 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.required_ruby_version = '>= 2.7'
-  spec.add_dependency 'countries', '~> 5.2'
+  spec.add_dependency 'countries', '~> 5.0'
   spec.add_dependency 'dry-configurable', '~> 1.0'
-  spec.add_dependency 'dry-container', '~> 0.11'
+  spec.add_dependency 'dry-container', '~> 0.10'
   spec.add_dependency 'dry-struct', '~> 1.6'
   spec.add_dependency 'dry-types', '~> 1.7'
   spec.add_dependency 'httparty', '~> 0.17'
-  spec.add_dependency 'jwt', '~> 2.6'
+  spec.add_dependency 'jwt', '~> 2.3'
 
   spec.add_development_dependency 'bundler', '~> 2.4'
   spec.add_development_dependency 'dotenv', '~> 2.8'

--- a/fortnox-api.gemspec
+++ b/fortnox-api.gemspec
@@ -24,12 +24,12 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.7'
   spec.add_dependency 'countries', '~> 5.2'
-  spec.add_dependency 'dry-configurable', '~> 1.0.1'
-  spec.add_dependency 'dry-container', '~> 0.11.0'
-  spec.add_dependency 'dry-struct', '~> 1.6.0'
-  spec.add_dependency 'dry-types', '~> 1.7.0'
-  spec.add_dependency 'httparty', '~> 0.17.3'
-  spec.add_dependency 'jwt', '~> 2.6.0'
+  spec.add_dependency 'dry-configurable', '~> 1.0'
+  spec.add_dependency 'dry-container', '~> 0.11'
+  spec.add_dependency 'dry-struct', '~> 1.6'
+  spec.add_dependency 'dry-types', '~> 1.7'
+  spec.add_dependency 'httparty', '~> 0.17'
+  spec.add_dependency 'jwt', '~> 2.6'
 
   spec.add_development_dependency 'bundler', '~> 2.4'
   spec.add_development_dependency 'dotenv', '~> 2.8'


### PR DESCRIPTION
New dependencies were too strict

We want to upgrade to `dry-core 1.0`, so therefore we need to run at least `dry-struct 1.6`, `dry-types 1.7`.